### PR TITLE
Ensure URLs are encoded and decoded properly

### DIFF
--- a/lib/laboratory/ui.rb
+++ b/lib/laboratory/ui.rb
@@ -19,13 +19,13 @@ module Laboratory
     end
 
     get '/experiments/:id/edit' do
-      @experiment = Laboratory::Experiment.find(params[:id])
+      @experiment = Laboratory::Experiment.find(CGI.unescape(params[:id]))
       erb :edit
     end
 
     # params = {variants: { control => 40, variant_a => 60 }}
     post '/experiments/:id/update_percentages' do
-      experiment = Laboratory::Experiment.find(params[:id])
+      experiment = Laboratory::Experiment.find(CGI.unescape(params[:id]))
 
       params[:variants].each do |variant_id, percentage|
         variant = experiment.variants.find { |v| v.id == variant_id }
@@ -38,7 +38,7 @@ module Laboratory
 
     # params = {variant_id: 'control', user_ids: []}
     post '/experiments/:id/assign_users' do
-      experiment = Laboratory::Experiment.find(params[:id])
+      experiment = Laboratory::Experiment.find(CGI.unescape(params[:id]))
       variant = experiment.variants.find { |v| v.id == params[:variant_id] }
       user_ids = params[:user_ids].split("\r\n")
 
@@ -51,7 +51,7 @@ module Laboratory
     end
 
     post '/experiments/:id/reset' do
-      experiment = Laboratory::Experiment.find(params[:id])
+      experiment = Laboratory::Experiment.find(CGI.unescape(params[:id]))
       experiment.reset
       redirect experiment_url(experiment)
     end

--- a/lib/laboratory/ui/helpers.rb
+++ b/lib/laboratory/ui/helpers.rb
@@ -9,19 +9,19 @@ module Laboratory
     end
 
     def experiment_url(experiment)
-      url('experiments', experiment.id, 'edit')
+      url('experiments', CGI.escape(experiment.id), 'edit')
     end
 
     def update_percentages_url(experiment)
-      url('experiments', experiment.id, 'update_percentages')
+      url('experiments', CGI.escape(experiment.id), 'update_percentages')
     end
 
     def assign_users_to_variant_url(experiment)
-      url('experiments', experiment.id, 'assign_users')
+      url('experiments', CGI.escape(experiment.id), 'assign_users')
     end
 
     def reset_experiment_url(experiment)
-      url('experiments', experiment.id, 'reset')
+      url('experiments', CGI.escape(experiment.id), 'reset')
     end
 
     def analysis_summary(experiment, event_id)


### PR DESCRIPTION
Since the experiment ids are set by the developer, we have to make sure
they are encoded and decoded properly when using them.