### PR TITLE
Allow variants to be overriden

### DIFF
--- a/lib/laboratory/experiment.rb
+++ b/lib/laboratory/experiment.rb
@@ -1,5 +1,20 @@
 module Laboratory
   class Experiment
+
+    class << self
+      def overrides
+        @overrides || {}
+      end
+
+      def override!(overrides)
+        @overrides = overrides
+      end
+
+      def clear_overrides!
+        @overrides = {}
+      end
+    end
+
     class UserNotInExperimentError < StandardError; end
     class ClashingExperimentIdError < StandardError; end
     class MissingExperimentIdError < StandardError; end
@@ -84,6 +99,8 @@ module Laboratory
     end
 
     def variant(user: Laboratory.config.current_user)
+      return variant_overridden_with if overridden?
+
       selected_variant = variants.find { |variant| variant.participant_ids.include?(user.id)}
       return selected_variant if !selected_variant.nil?
 
@@ -164,6 +181,14 @@ module Laboratory
     end
 
     private
+
+    def overridden?
+      self.class.overrides.key?(id) && variant_overridden_with != nil
+    end
+
+    def variant_overridden_with
+      variants.find { |v| v.id == self.class.overrides[id] }
+    end
 
     def changeset
       set = {}

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -332,6 +332,30 @@ RSpec.describe Laboratory::Experiment do
         expect(outputs).to eq(expected_outputs)
       end
     end
+
+    context 'when the experiment is overridden' do
+      it 'returns the overridden variant' do
+        id = 1
+        variants = [
+          {
+            id: 'control',
+            percentage: 40
+          },
+          {
+            id: 'variant_a',
+            percentage: 60
+          }
+        ]
+        variant_to_override_with = 'variant_a'
+
+        experiment = described_class.create(id: id, variants: variants)
+        overrides = {}
+        overrides[experiment.id] = variant_to_override_with
+        described_class.override!(overrides)
+
+        expect(experiment.variant.id).to eq(variant_to_override_with)
+      end
+    end
   end
 
   describe '#assign_to_variant' do


### PR DESCRIPTION
Sometimes, when QA'ing or developing an experiment, you'll want to easily switch between variants without having to jump into the console. This can be managed via a url parameter by adding the following snippet to your application controller (this example is for Rails, but a similar approach would work for other frameworks):

```ruby

around_action :override_laboratory_experiments!

def override_laboratory_experiments!
  Laboratory::Experiment.override!(params[:exp])
  yield
  Laboratory::Experiment.clear_overrides!
end
```

This then allows you navigate to a urls like:

http://yourwebsite.com?exp[blue_button_ab_test]=variant_a

and

http://yourwebsite.com?exp[blue_button_ab_test]=control

This commit implements this.