### PR TITLE
Ensure Laboratory is thread-safe

### DIFF
--- a/lib/laboratory.rb
+++ b/lib/laboratory.rb
@@ -17,7 +17,7 @@ require 'laboratory/calculations/confidence_level'
 module Laboratory
   class << self
     def config
-      Laboratory::Config
+      Thread.current[:laboratory_config] ||= Laboratory::Config.new
     end
   end
 end

--- a/lib/laboratory/config.rb
+++ b/lib/laboratory/config.rb
@@ -1,17 +1,15 @@
 module Laboratory
   class Config
-    class << self
-      attr_accessor(
-        :current_user_id,
-        :adapter,
-        :actor,
-        :on_assignment_to_variant,
-        :on_event_recorded
-      )
+    attr_accessor(
+      :current_user_id,
+      :adapter,
+      :actor,
+      :on_assignment_to_variant,
+      :on_event_recorded
+    )
 
-      def current_user
-        @current_user ||= Laboratory::User.new(id: current_user_id)
-      end
+    def current_user
+      @current_user ||= Laboratory::User.new(id: current_user_id)
     end
   end
 end

--- a/lib/laboratory/experiment.rb
+++ b/lib/laboratory/experiment.rb
@@ -110,7 +110,7 @@ module Laboratory
       variant = algorithm.pick!(variants)
       variant.add_participant(user)
 
-      Laboratory::Config.on_assignment_to_variant&.call(self, variant, user)
+      Laboratory.config.on_assignment_to_variant&.call(self, variant, user)
 
       save
       variant
@@ -124,7 +124,7 @@ module Laboratory
       variant = variants.find { |s| s.id == variant_id }
       variant.add_participant(user)
 
-      Laboratory::Config.on_assignment_to_variant&.call(self, variant, user)
+      Laboratory.config.on_assignment_to_variant&.call(self, variant, user)
 
       save
       variant
@@ -147,7 +147,7 @@ module Laboratory
 
       event.event_recordings << event_recording
 
-      Laboratory::Config.on_event_recorded&.call(self, variant, user, event)
+      Laboratory.config.on_event_recorded&.call(self, variant, user, event)
 
       save
       event_recording

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -2,22 +2,22 @@
 
 RSpec.describe Laboratory::Config do
   it 'should have an attr_accessor called adapter' do
-    expect(described_class).to have_attr_accessor(:adapter)
+    expect(described_class.new).to have_attr_accessor(:adapter)
   end
 
   it 'should have an attr_accessor called current_user_id' do
-    expect(described_class).to have_attr_accessor(:current_user_id)
+    expect(described_class.new).to have_attr_accessor(:current_user_id)
   end
 
   it 'should have an attr_accessor called actor' do
-    expect(described_class).to have_attr_accessor(:actor)
+    expect(described_class.new).to have_attr_accessor(:actor)
   end
 
   it 'should have an attr_accessor called on_assignment_to_variant' do
-    expect(described_class).to have_attr_accessor(:on_assignment_to_variant)
+    expect(described_class.new).to have_attr_accessor(:on_assignment_to_variant)
   end
 
   it 'should have an attr_accessor called on_event_recorded' do
-    expect(described_class).to have_attr_accessor(:on_event_recorded)
+    expect(described_class.new).to have_attr_accessor(:on_event_recorded)
   end
 end


### PR DESCRIPTION
Here at Butternut, we use a Puma web server for our core application.
This means we have to always be mindful of the impact we have on the
multi-threaded environment we work in. There is a great summary here of
some of the issues that can occur in a Puma environment if thread safety
isn't managed carefully:

https://www.rubytapas.com/2016/11/20/ruby-thread-local-variables/

We want to make sure Laboratory is thread safe. Upto now, the Config
definition in Laboratory was not threadsafe as it was a single global
class with attr_accessor variables that every thread would change. This
commit solves this by doing the following:

* Redesigns `Laboratory::Config` to move the attr_accessor's to the
instance of the class, rather than the class itself.
* Then redefines Laboratory.config to use the current thread's
`laboratory_config` variable, or defines that variable as a new instance
of `Laboratory::Config`.

This results in each thread having a separate config instance.
