### PR TITLE
Refactor position of the adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Or install it yourself as:
 In an initializer (`app/config/initializers/laboratory.rb`), define the adapter you are going to use with Laboratory. Laboratory supports Redis out of the box, as it the recommended adapter:
 
 ```ruby
-Laboratory.config.adapter = Laboratory::Adapters::RedisAdapter.new(url: 'redis://localhost:6789') # Adjust to your redis URL.
+Laboratory.adapter = Laboratory::Adapters::RedisAdapter.new(url: 'redis://localhost:6789') # Adjust to your redis URL.
 ```
 
 ### Defining your current_user_id & actor

--- a/lib/laboratory.rb
+++ b/lib/laboratory.rb
@@ -16,6 +16,8 @@ require 'laboratory/calculations/confidence_level'
 
 module Laboratory
   class << self
+    attr_accessor :adapter
+
     def config
       Thread.current[:laboratory_config] ||= Laboratory::Config.new
     end

--- a/lib/laboratory/config.rb
+++ b/lib/laboratory/config.rb
@@ -2,7 +2,6 @@ module Laboratory
   class Config
     attr_accessor(
       :current_user_id,
-      :adapter,
       :actor,
       :on_assignment_to_variant,
       :on_event_recorded

--- a/lib/laboratory/experiment.rb
+++ b/lib/laboratory/experiment.rb
@@ -56,7 +56,7 @@ module Laboratory
     end
 
     def self.all
-      Laboratory.config.adapter.read_all
+      Laboratory.adapter.read_all
     end
 
     def self.create(id:, variants:, algorithm: Algorithms::Random)
@@ -73,7 +73,7 @@ module Laboratory
     end
 
     def self.find(id)
-      Laboratory.config.adapter.read(id)
+      Laboratory.adapter.read(id)
     end
 
     def self.find_or_create(id:, variants:, algorithm: Algorithms::Random)
@@ -81,7 +81,7 @@ module Laboratory
     end
 
     def delete
-      Laboratory.config.adapter.delete(id)
+      Laboratory.adapter.delete(id)
       nil
     end
 
@@ -169,7 +169,7 @@ module Laboratory
 
         @changelog << changelog_item
       end
-      Laboratory.config.adapter.write(self)
+      Laboratory.adapter.write(self)
     end
 
     def valid? # rubocop:disable Metrics/AbcSize

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 RSpec.describe Laboratory::Config do
-  it 'should have an attr_accessor called adapter' do
-    expect(described_class.new).to have_attr_accessor(:adapter)
-  end
-
   it 'should have an attr_accessor called current_user_id' do
     expect(described_class.new).to have_attr_accessor(:current_user_id)
   end

--- a/spec/experiment_spec.rb
+++ b/spec/experiment_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-Laboratory.config.adapter = Laboratory::Adapters::MockAdapter.new
+Laboratory.adapter = Laboratory::Adapters::MockAdapter.new
 
 RSpec.describe Laboratory::Experiment do
   before(:each) do
-    Laboratory.config.adapter.delete_all
+    Laboratory.adapter.delete_all
   end
 
   it 'should have an attr_reader called id' do
@@ -477,7 +477,7 @@ RSpec.describe Laboratory::Experiment do
       ]
 
       experiment = described_class.new(id: id, variants: variants)
-      expect(Laboratory.config.adapter).to receive(:write).with(experiment)
+      expect(Laboratory.adapter).to receive(:write).with(experiment)
       experiment.save
     end
   end


### PR DESCRIPTION
In a previous commit, we made the `Laboratory::Config` class threadsafe.
However, by doing this, we made the adapter variable local to the
current thread. This would mean having to define it on every thread,
which is unlikely to be what is required. This commit moves it up a
level onto the `Laboratory` object so it can be accessed directly from
there as a single global attribute.