### PR TITLE
Ensure Experiment#overrides is thread-safe

### DIFF
--- a/lib/laboratory/experiment.rb
+++ b/lib/laboratory/experiment.rb
@@ -2,15 +2,15 @@ module Laboratory
   class Experiment # rubocop:disable Metrics/ClassLength
     class << self
       def overrides
-        @overrides || {}
+        Thread.current[:experiment_overrides] || {}
       end
 
       def override!(overrides)
-        @overrides = overrides
+        Thread.current[:experiment_overrides] = overrides
       end
 
       def clear_overrides!
-        @overrides = {}
+        Thread.current[:experiment_overrides] = {}
       end
     end
 


### PR DESCRIPTION
Previously, Experiment#overrides was not thread-safe. This commit
ensures that it is, and adds tests for the methods managing overrides.
