### PR TITLE
Ensure experiment analysis ignores duplicate event recordings for a user

### DIFF
--- a/lib/laboratory/experiment/analysis_summary.rb
+++ b/lib/laboratory/experiment/analysis_summary.rb
@@ -41,7 +41,7 @@ module Laboratory
 
       def event_total_count_for_variant(variant)
         event = event_for_variant(variant)
-        event.event_recordings.count
+        event.event_recordings.uniq(&:user_id).count
       end
 
       def conversion_rate_for_variant(variant)


### PR DESCRIPTION
We allow multiple event recordings for a user on an event, but we should
not factor that when analysing an experiment. This commit ensures this
is the case.
